### PR TITLE
Stopping event bubbling

### DIFF
--- a/zoomy.js
+++ b/zoomy.js
@@ -514,8 +514,8 @@
 									    }
 									
 								    },
-								    'click': function () {
-									    return false;
+								    'click': function (e) {
+									    e.preventDefault();
 								    }
 							    };
 						    


### PR DESCRIPTION
```
'click': function () {
    return false;
}
```

Does

```
'click: function ( e ) {
    e.preventDefault();
    e.stopPropagation();
}
```

Where as I don't think stopping propagation is the intention, which can affect the functionality of code not related to the plugin. It can be worked around by setting `clickable` option to `true` but then the user must handle `.preventDefault()` (or other workaround) themselves.

See http://stackoverflow.com/questions/11180598/jquery-is-not-catching-click-on-some-content-loaded/11180876
